### PR TITLE
Add local image & video files

### DIFF
--- a/frontend/src/components/AddRecipeForm.jsx
+++ b/frontend/src/components/AddRecipeForm.jsx
@@ -9,14 +9,15 @@ import Checkbox from '@mui/material/Checkbox';
 import Autocomplete from '@mui/material/Autocomplete';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import CancelIcon from '@mui/icons-material/Cancel';
+
 
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
 const AddRecipeCard = ({ handleSubmit, initialData }) => {
-    const available_tags = ["Easy", "Indian", "Vegan", "Gluten free", "Comfort food", "Under 15 min"]
-    
+  const available_tags = ["Easy", "Indian", "Vegan", "Gluten free", "Comfort food", "Under 15 min"]    
   const [minutes, setMinutes] = React.useState(initialData?.cooking_time || '');
   const [image, setImage] = React.useState(initialData?.image || '' );
   const [ingredients, setIngredients] = React.useState(initialData?.ingredients || "• ");
@@ -102,15 +103,17 @@ const AddRecipeCard = ({ handleSubmit, initialData }) => {
       };
 
       const handleFileChange = (event) => {
-        const imagePath = event.target.value;
-        
-        if (imagePath.trim()) {
-          setImage(imagePath);
-        } else {
-          setImage("");
-        }
-      };
-
+        const file = event.target.files[0];
+        if (!file) return;
+    
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onloadend = () => {
+            setImage(reader.result); 
+        };
+    };
+    
+    
   const handleSubmitForm = () => {
     if (!isFormValid || isSubmitting) return;
     
@@ -120,17 +123,8 @@ const AddRecipeCard = ({ handleSubmit, initialData }) => {
       ingredients,
       minutes,
       tags,
-      image
+      image,
     });
-    const updatedData = {
-      name,
-      description,
-      ingredients, // ingredients
-      minutes,
-      tags,
-      image
-    };
-    console.log("Submit data:", image);
   
   };
   
@@ -246,20 +240,33 @@ const AddRecipeCard = ({ handleSubmit, initialData }) => {
 
           <div 
               className="montserrat-font p-6 border border-gray-300 rounded-[5px] w-[400px] ml-10 flex items-center justify-center flex-col">
-            <div className="font-bold text-gray-500">Add an image</div>
-            <div>
-              <input
-                type="text"
-                className="border-2 border-gray-500 p-2 rounded-md w-full focus:outline-none text-black"
-                onChange={handleFileChange}
-                value={image}
-                placeholder="Enter image path here"
-              />
+            <div className="font-bold text-gray-500">Add an image or video</div>
+
+            {image && image !== "" ? (
+              <div className="relative">
+              <div 
+                className="absolute top-0 right-0 m-2 cursor-pointer text-gray-300 z-10"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setImage('');
+                }}
+              >
+                <CancelIcon />
+              </div>
+    
+              {image.startsWith("data:video") ? (
+                <video controls className="w-[200px] h-[200px] object-cover rounded-2xl">
+                  <source src={image} type="video/mp4" />
+                  Your browser does not support the video tag.
+                </video>
+              ) : (
+                <img src={image} className="w-[200px] h-[200px] object-cover rounded-2xl" alt="Dish" />
+              )}
             </div>
-              {/*
-            <div className="text-gray-500">
-              {fileName ? fileName : "Drag and drop a file here"}
-            </div>
+              ) : (
+                <input type="file" className="mt-0" />
+              )}
+
               
             <div className="bg-green-700 text-white p-2 mt-4 rounded-[5px] hover:bg-green-800 cursor-pointer"
             onClick={() => document.getElementById("fileInput").click()}
@@ -270,16 +277,17 @@ const AddRecipeCard = ({ handleSubmit, initialData }) => {
                 id="fileInput" 
                 className="hidden" 
                 onChange={handleFileChange} 
+                accept="image/*, video/*"
             />
               Browse Files
             </div>
-            */}
+            
           </div>
         </div>
 
         <div
           className={`font-bold text-xl p-2 mt-20 rounded-[5px] w-fit items-center ${
-            isFormValid ? 'bg-green-700 text-white hover:bg-green-800 cursor-pointer' : 'bg-gray-400 text-white cursor-not-allowed'
+            isFormValid ? 'bg-green-700 text-white hover:bg-green-800 cursor-pointer' : 'text-white cursor-not-allowed'
           }`}
           onClick={isFormValid && !isSubmitting ? handleSubmitForm : null}
         >

--- a/frontend/src/components/RecipeCard.jsx
+++ b/frontend/src/components/RecipeCard.jsx
@@ -2,19 +2,25 @@ import React from "react";
 import BookmarkBorderOutlinedIcon from "@mui/icons-material/BookmarkBorderOutlined";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
 
-const RecipeCard = ({ image, video, name, username, tags, small, isBookmarked, onToggleBookmark, onFullDetailsClick }) => {
+const RecipeCard = ({ image, name, username, tags, small, isBookmarked, onToggleBookmark, onFullDetailsClick }) => {
   return (
     <div className={`relative bg-white rounded-2xl shadow-lg border border-gray-200 ${small ? "w-[400px] min-w-[350px]" : "w-[500px] min-w-[400px]"} mx-auto bg-gray-100`}>
       <div className="relative overflow-hidden rounded-t-2xl">
-        {video ? (
-          <video src={video} className="w-full h-[300px] object-cover" controls />
+      {image.startsWith("data:video") ? (
+          <video 
+            controls 
+            className="w-full h-[300px] object-cover cursor-pointer"
+          >
+            <source src={image} type="video/mp4"  onClick={onFullDetailsClick}/>
+            Your browser does not support the video tag.
+          </video>
         ) : (
           <img src={image} alt={name} className="w-full h-[300px] object-cover cursor-pointer" onClick={onFullDetailsClick}/>
         )}
       </div>
 
       <div className="p-6">
-        <h3 className="text-2xl font-bold text-gray-800" onClick={onFullDetailsClick}>{name}</h3>
+        <h3 className="text-2xl font-bold text-gray-800 cursor-pointer" onClick={onFullDetailsClick}>{name}</h3>
         <p className="text-lg text-gray-500 mt-2">{username}</p>
         <div className="flex flex-wrap gap-2 mt-4">
           {tags.map((tag, index) => (

--- a/frontend/src/pages/DishDetailsPage.jsx
+++ b/frontend/src/pages/DishDetailsPage.jsx
@@ -79,7 +79,6 @@ const RecipeDetailsPage = () => {
   };
 
   const handleDelete = async () => {
-    console.log("id", recipeId)
     try {
       const response = await deleteRecipeByID(recipeId); // Call the delete function
       console.log("api response", response);
@@ -98,7 +97,8 @@ const RecipeDetailsPage = () => {
 
 
   return (
-    <div className="pt-24 montserrat-font flex flex-col items-center justify-center w-screen min-h-screen px-4">
+    
+    <div className="pt-24 pb-40 montserrat-font flex flex-col items-center justify-center w-screen min-h-screen px-4">
       <div className="w-full flex flex-col items-center">
         
       <h1 className="mt-6 top-6 text-green-600 text-7xl font-bold items-center">{recipe.name}</h1>
@@ -145,11 +145,22 @@ const RecipeDetailsPage = () => {
       </Menu>
     </div>
       <div className="w-[400px] md:w-[1000px]">
-        <img src={recipe.image} className="w-[400px] h-[250px] md:w-[1000px] md:h-[400px] object-cover my-4 rounded-2xl" />
-        
+      <div className="w-[400px] h-[250px] md:w-[1000px] md:h-[400px] my-4 rounded-2xl flex items-center justify-center border border-gray-400 bg-gray-100">
+      {recipe.image ? (
+        recipe.image.startsWith("data:video") ? (
+          <video controls className="w-full h-full object-cover rounded-2xl">
+            <source src={recipe.image} type="video/mp4" />
+            Your browser does not support the video tag.
+          </video>
+        ) : (
+          <img src={recipe.image} className="w-full h-full object-cover rounded-2xl" alt="Dish" />
+        )
+      ) : (
+        <p className="text-gray-600 text-xl font-semibold">No image available</p>
+      )}
+    </div>
 
         <div className="flex flex-row w-full mt-5">
-          
           <div className="w-1/2 pr-8">
             <p className="text-2xl md:text-3xl font-bold mb-4">Ingredients</p>
             {recipe.ingredients ? (
@@ -170,35 +181,35 @@ const RecipeDetailsPage = () => {
 
           <div className="w-1/2 pl-8">
             <p className="text-2xl md:text-3xl font-bold mb-4">Description</p>
-            <div className="border-t border-gray-300 w-full"></div>
+            <div className="border-t border-gray-300 w-full"/>
             <p className="text-base md:text-lg text-left mt-4">{recipe.description}</p>
           </div>
         </div>
 
         {recipe.tags && recipe.tags.length > 0 && (
-    <div className="flex flex-wrap gap-2 mt-10 mb-6 w-full">
-      {recipe.tags.map((tag, index) => (
-        <span
-          key={index}
-          className="bg-green-200 text-green-700 px-6 py-2 rounded-full text-sm font-medium"
-        >
-          {tag}
-        </span>
-      ))}
-    </div>
-  )}
+        <div className="flex flex-wrap gap-2 mt-10 mb-6 w-full">
+          {recipe.tags.map((tag, index) => (
+            <span
+              key={index}
+              className="bg-green-200 text-green-700 px-6 py-2 rounded-full text-sm font-medium"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+        )}
 
       </div>
       {isEditOpen && (
         <div className="text-black flex items-center justify-center w-full h-screen fixed top-0 left-0 bg-white ">
           <div className="w-full max-w-4xl p-4 pt-24">
-          <h1 className="text-3xl font-bold mt-6 top-6 text-green-600 z-20 text-center mb-12">
-            Update Recipe
-          </h1>
-            <AddRecipeCard
-              handleSubmit={handleUpdate}
-              initialData={recipe}
-            />
+            <h1 className="text-3xl font-bold mt-6 top-6 text-green-600 z-20 text-center mb-12">
+              Update Recipe
+            </h1>
+              <AddRecipeCard
+                handleSubmit={handleUpdate}
+                initialData={recipe}
+              />
           </div>
         </div>
       )}

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -125,6 +125,10 @@ const UserProfilePage = ({ user: initialUser }) => {
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
               {recipes.map((recipe) => (
+                <div 
+                key={recipe.id} 
+                className="transform transition-transform duration-300 hover:scale-102"
+              >
                 <RecipeCard
                   key={recipe.id}
                   image={recipe.image}
@@ -136,7 +140,9 @@ const UserProfilePage = ({ user: initialUser }) => {
                   onToggleBookmark={() => handleToggleBookmark(recipe.id)}
                   onFullDetailsClick={() => handleRecipeClick(recipe.id)}
                   small
+                  
                 />
+                </div>
               ))}
             </div>
           )}


### PR DESCRIPTION
Now you can:
- Add local img or video to recipe
- Delete it from the form

Other fixes:
- When hovering over a recipe card in user profile, it expands. An alternative is to let it have a shadow when hovering
- Padding bottom is added to recipe details
- If theres no image or video, "No image available" is rendered

Comments:
In the user profile, if you click on the video section of the recipe card, the video starts playing. Compared to if its an image, when clicking on the image you will get to details page. I dont know if we want the same behaviour for video or if its nice to have the video playing when clicking on it

It's not drag and drop now. You just click on the button which will open your files