### PR TITLE
fix ingredients and instruction parsing

### DIFF
--- a/backend/services/recipe_service.py
+++ b/backend/services/recipe_service.py
@@ -36,7 +36,7 @@ class RecipeService:
 
             tags = ", ".join(item.get("tags", []))
             ingredients = "\n".join(item.get("ingredients", []))
-            instructions = "\n".join(item.get("instructions", []))
+            instructions = "\n".join([f"{idx+1}. {step}" for idx, step in enumerate(item.get("instructions", []))])
             cuisine = item.get("cuisine", "global")
             description = f"A delicious {cuisine.lower()} dish"
 

--- a/frontend/src/components/FlipRecipeCard.jsx
+++ b/frontend/src/components/FlipRecipeCard.jsx
@@ -22,13 +22,10 @@ const FlipRecipeCard = ({
   const [isFlipped, setIsFlipped] = useState(false);
   const navigate = useNavigate();
   const normalizedIngredients = typeof ingredients === 'string'
-  ? (ingredients.includes('•')
-      ? ingredients.split('•').map(item => item.trim()).filter(Boolean)
-      : ingredients.split(',').map(item => item.trim()).filter(Boolean))
+  ? ingredients.split(/\n|•|,/).map(item => item.trim()).filter(Boolean)
   : Array.isArray(ingredients)
     ? ingredients
     : [];
-
 
   const handleRecipeClick = (recipeID) => {
     navigate(`/app/${recipeID}`);

--- a/frontend/src/pages/DishDetailsPage.jsx
+++ b/frontend/src/pages/DishDetailsPage.jsx
@@ -107,7 +107,6 @@ const RecipeDetailsPage = () => {
     setAnchorEl(null);
   };
 
-
   return (
     
     <div className="pt-24 pb-40 montserrat-font flex flex-col items-center justify-center w-screen min-h-screen px-4">


### PR DESCRIPTION
when the dummy recipe data is seeded, the ingredients are parsed correctly on the recipe flip cards in the homepage and instructions are parsed properly in the dish details page